### PR TITLE
Refactor into modules

### DIFF
--- a/src/bin/new-release.rs
+++ b/src/bin/new-release.rs
@@ -67,5 +67,5 @@ fn main() {
     info!(log, "Created release {}", new_release.version);
 
     info!(log, "Assigning commits for {}", new_release.version);
-    contributors::assign_commits(&log, &new_release.version, &release.version, project.id, &path);
+    contributors::releases::assign_commits(&log, &new_release.version, &release.version, project.id, &path);
 }

--- a/src/bin/new-release.rs
+++ b/src/bin/new-release.rs
@@ -63,7 +63,7 @@ fn main() {
        panic!("Release {} already exists! Something must be wrong.", new_release_name);
     }
 
-    let new_release = contributors::create_release(&connection, &new_release_name, project.id);
+    let new_release = contributors::releases::create(&connection, &new_release_name, project.id);
     info!(log, "Created release {}", new_release.version);
 
     info!(log, "Assigning commits for {}", new_release.version);

--- a/src/bin/populate.rs
+++ b/src/bin/populate.rs
@@ -131,10 +131,10 @@ fn main() {
 
     let releases: Vec<&str> = releases.collect();
     for release in releases.iter() {
-        contributors::create_release(&connection, release, project.id);
+        contributors::releases::create(&connection, release, project.id);
     }
     // And create the release for all commits that are not released yet
-    contributors::create_release(&connection, "master", project.id);
+    contributors::releases::create(&connection, "master", project.id);
 
     // create most commits
     //

--- a/src/bin/populate.rs
+++ b/src/bin/populate.rs
@@ -99,7 +99,7 @@ fn main() {
     info!(log, "GitHub name: {}", github_name);
 
     // create project
-    let project = contributors::create_project(&connection, project_name, url_path, github_name);
+    let project = contributors::projects::create(&connection, project_name, url_path, github_name);
 
     // Create releases
     // Infer them from git tags

--- a/src/bin/populate.rs
+++ b/src/bin/populate.rs
@@ -177,7 +177,7 @@ fn main() {
 
             // We tag all commits initially to the first release. Each release will
             // set this properly below.
-            contributors::create_commit(&connection, &sha, &author_name, &author_email, &first_release);
+            contributors::commits::create(&connection, &sha, &author_name, &author_email, &first_release);
         }
     }
 

--- a/src/bin/populate.rs
+++ b/src/bin/populate.rs
@@ -186,7 +186,7 @@ fn main() {
     for (i, v1) in releases.iter().enumerate() {
         let v2 = releases.get(i+1).unwrap_or(&master);
         println!("({}, {})", v1, v2);
-        contributors::assign_commits(&log, v2, v1, project.id, &path);
+        contributors::releases::assign_commits(&log, v2, v1, project.id, &path);
     }
 
 

--- a/src/bin/update-commit-db.rs
+++ b/src/bin/update-commit-db.rs
@@ -82,7 +82,7 @@ fn update_commit_db(log: &slog::Logger, project: &Project, connection: &PgConnec
             Err(_) => {
                 info!(log, "Creating commit {} for release {}", object.sha, master_release.version);
                 // this commit will be part of master
-                contributors::create_commit(connection, &object.sha, &object.commit.author.name, &object.commit.author.email, &master_release);
+                contributors::commits::create(connection, &object.sha, &object.commit.author.name, &object.commit.author.email, &master_release);
             },
         };
     }

--- a/src/commits.rs
+++ b/src/commits.rs
@@ -1,0 +1,21 @@
+use models::{Commit, NewCommit};
+use models::Release;
+
+use diesel;
+use diesel::pg::PgConnection;
+use diesel::prelude::*;
+
+pub fn create<'a>(conn: &PgConnection, sha: &'a str, author_name: &'a str, author_email: &'a str, release: &Release) -> Commit {
+    use schema::commits;
+
+    let new_commit = NewCommit {
+        sha: sha,
+        release_id: release.id,
+        author_name: author_name,
+        author_email: author_email,
+    };
+
+    diesel::insert(&new_commit).into(commits::table)
+        .get_result(conn)
+        .expect("Error saving new commit")
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@ pub mod commits;
 
 use self::models::Project;
 use self::models::{Commit, NewCommit};
-use self::models::{Release, NewRelease};
+use self::models::Release;
 
 use unicode_normalization::UnicodeNormalization;
 
@@ -62,19 +62,6 @@ pub fn create_commit<'a>(conn: &PgConnection, sha: &'a str, author_name: &'a str
         .expect("Error saving new commit")
 }
 
-
-pub fn create_release(conn: &PgConnection, version: &str, project_id: i32) -> Release {
-    use schema::releases;
-
-    let new_release = NewRelease {
-        version: version,
-        project_id: project_id,
-    };
-
-    diesel::insert(&new_release).into(releases::table)
-        .get_result(conn)
-        .expect("Error saving new release")
-}
 
 
 fn char_cmp(a_char: char, b_char: char) -> Ordering {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,10 +29,6 @@ pub mod projects;
 pub mod releases;
 pub mod commits;
 
-use self::models::{Commit, NewCommit};
-use self::models::Release;
-
-
 use serde_json::value::Value;
 
 pub fn establish_connection() -> PgConnection {
@@ -43,26 +39,6 @@ pub fn establish_connection() -> PgConnection {
     PgConnection::establish(&database_url)
         .expect(&format!("Error connecting to {}", database_url))
 }
-
-pub fn create_commit<'a>(conn: &PgConnection, sha: &'a str, author_name: &'a str, author_email: &'a str, release: &Release) -> Commit {
-    use schema::commits;
-
-    let new_commit = NewCommit {
-        sha: sha,
-        release_id: release.id,
-        author_name: author_name,
-        author_email: author_email,
-    };
-
-    diesel::insert(&new_commit).into(commits::table)
-        .get_result(conn)
-        .expect("Error saving new commit")
-}
-
-
-
-
-
 
 pub fn scores() -> Vec<Value> {
     use schema::commits::dsl::*;
@@ -108,4 +84,3 @@ pub fn scores() -> Vec<Value> {
         Value::Object(json_score)
     }).collect()
 }
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,6 @@ extern crate unicode_normalization;
 use std::collections::BTreeMap;
 use std::env;
 use std::cmp::Ordering;
-use std::process::Command;
 
 extern crate serde_json;
 
@@ -123,84 +122,6 @@ fn str_cmp(a_raw: &str, b_raw: &str) -> Ordering {
 // TODO: switch this out for an implementation of the Unicode Collation Algorithm
 pub fn inaccurate_sort(strings: &mut Vec<String>) {
     strings.sort_by(|a, b| str_cmp(&a, &b));
-}
-
-pub fn assign_commits(log: &slog::Logger, release_name: &str, previous_release: &str, release_project_id: i32, path: &str) {
-    // Could take the connection as a parameter, as problably
-    // it's already established somewhere...
-    let connection = establish_connection();
-
-    info!(log, "Assigning commits to release {}", release_name);
-
-    let git_log = Command::new("git")
-        .arg("-C")
-        .arg(&path)
-        .arg("--no-pager")
-        .arg("log")
-        .arg("--use-mailmap")
-        .arg(r#"--format=%H"#)
-        .arg(&format!("{}...{}", previous_release, release_name))
-        .output()
-        .expect("failed to execute process");
-
-    let git_log = git_log.stdout;
-    let git_log = String::from_utf8(git_log).unwrap();
-
-    for sha_name in git_log.split('\n') {
-        // there is a last, blank line
-        if sha_name == "" {
-            continue;
-        }
-
-        info!(log, "Assigning commit {} to release {}", sha_name, release_name);
-
-        use schema::releases::dsl::*;
-        use models::Release;
-        use schema::commits::dsl::*;
-        use models::Commit;
-
-        let the_release = releases
-            .filter(version.eq(&release_name))
-            .filter(project_id.eq(release_project_id))
-            .first::<Release>(&connection)
-            .expect("could not find release");
-
-        // did we make this commit earlier? If so, update it. If not, create it
-        match commits.filter(sha.eq(&sha_name)).first::<Commit>(&connection) {
-            Ok(the_commit) => {
-                diesel::update(commits.find(the_commit.id))
-                    .set(release_id.eq(the_release.id))
-                    .get_result::<Commit>(&connection)
-                    .expect(&format!("Unable to update commit {}", the_commit.id));
-            },
-            Err(_) => {
-                let git_log = Command::new("git")
-                    .arg("-C")
-                    .arg(&path)
-                    .arg("--no-pager")
-                    .arg("show")
-                    .arg(r#"--format=%H %ae %an"#)
-                    .arg(&sha_name)
-                    .output()
-                    .expect("failed to execute process");
-
-                let git_log = git_log.stdout;
-                let git_log = String::from_utf8(git_log).unwrap();
-
-                let log_line = git_log.split('\n').nth(0).unwrap();
-
-                let mut split = log_line.splitn(3, ' ');
-
-                let the_sha = split.next().unwrap();
-                let the_author_email = split.next().unwrap();
-                let the_author_name = split.next().unwrap();
-
-                info!(log, "Creating commit {} for release {}", the_sha, the_release.version);
-
-                create_commit(&connection, &the_sha, &the_author_name, &the_author_email, &the_release);
-            },
-        };
-    }
 }
 
 pub fn releases() -> Vec<Value> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,29 +63,6 @@ pub fn create_commit<'a>(conn: &PgConnection, sha: &'a str, author_name: &'a str
 
 
 
-pub fn releases() -> Vec<Value> {
-    use schema::releases::dsl::*;
-    use models::Release;
-    use models::Project;
-
-    let connection = establish_connection();
-
-    let project = {
-        use schema::projects::dsl::*;
-        projects.filter(name.eq("Rust"))
-            .first::<Project>(&connection)
-        .expect("Error finding the Rust project")
-    };
-
-    let results = releases.filter(project_id.eq(project.id))
-        .load::<Release>(&connection)
-        .expect("Error loading releases");
-
-    results.into_iter()
-        .rev()
-        .map(|r| Value::String(r.version))
-        .collect()
-}
 
 pub fn scores() -> Vec<Value> {
     use schema::commits::dsl::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,11 @@ extern crate slog_term;
 pub mod schema;
 pub mod models;
 
-use self::models::{Project, NewProject};
+pub mod projects;
+pub mod releases;
+pub mod commits;
+
+use self::models::Project;
 use self::models::{Commit, NewCommit};
 use self::models::{Release, NewRelease};
 
@@ -57,20 +61,6 @@ pub fn create_commit<'a>(conn: &PgConnection, sha: &'a str, author_name: &'a str
     diesel::insert(&new_commit).into(commits::table)
         .get_result(conn)
         .expect("Error saving new commit")
-}
-
-pub fn create_project(conn: &PgConnection, name: &str, url_path: &str, github_name: &str) -> Project {
-    use schema::projects;
-
-    let new_project = NewProject {
-        name: name,
-        url_path: url_path,
-        github_name: github_name
-    };
-
-    diesel::insert(&new_project).into(projects::table)
-        .get_result(conn)
-        .expect("Error saving new project")
 }
 
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -67,7 +67,7 @@ fn root(_: Request) -> futures::Finished<Response, hyper::Error> {
 
 
     data.insert("releases".to_string(),
-                Value::Array(contributors::releases()));
+                Value::Array(contributors::releases::all()));
 
     let template = build_template(&data, "templates/index.hbs");
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -114,7 +114,7 @@ fn release(_: &Request, cap: Captures) -> futures::Finished<Response, hyper::Err
 
     data.insert("release".to_string(), Value::String(release_name.to_string()));
 
-    let names = contributors::names(project, release_name);
+    let names = contributors::releases::contributors(project, release_name);
 
     match names {
         Some(names) => {

--- a/src/projects.rs
+++ b/src/projects.rs
@@ -1,0 +1,20 @@
+use models::{NewProject, Project};
+
+use diesel;
+use diesel::pg::PgConnection;
+use diesel::prelude::*;
+
+pub fn create(conn: &PgConnection, name: &str, url_path: &str, github_name: &str) -> Project {
+    use schema::projects;
+
+    let new_project = NewProject {
+        name: name,
+        url_path: url_path,
+        github_name: github_name
+    };
+
+    diesel::insert(&new_project).into(projects::table)
+        .get_result(conn)
+        .expect("Error saving new project")
+}
+

--- a/src/releases.rs
+++ b/src/releases.rs
@@ -1,0 +1,85 @@
+use diesel;
+use diesel::prelude::*;
+
+use std::process::Command;
+
+use slog::Logger;
+
+pub fn assign_commits(log: &Logger, release_name: &str, previous_release: &str, release_project_id: i32, path: &str) {
+    // Could take the connection as a parameter, as problably
+    // it's already established somewhere...
+    let connection = ::establish_connection();
+
+    info!(log, "Assigning commits to release {}", release_name);
+
+    let git_log = Command::new("git")
+        .arg("-C")
+        .arg(&path)
+        .arg("--no-pager")
+        .arg("log")
+        .arg("--use-mailmap")
+        .arg(r#"--format=%H"#)
+        .arg(&format!("{}...{}", previous_release, release_name))
+        .output()
+        .expect("failed to execute process");
+
+    let git_log = git_log.stdout;
+    let git_log = String::from_utf8(git_log).unwrap();
+
+    for sha_name in git_log.split('\n') {
+        // there is a last, blank line
+        if sha_name == "" {
+            continue;
+        }
+
+        info!(log, "Assigning commit {} to release {}", sha_name, release_name);
+
+        use schema::releases::dsl::*;
+        use models::Release;
+        use schema::commits::dsl::*;
+        use models::Commit;
+
+        let the_release = releases
+            .filter(version.eq(&release_name))
+            .filter(project_id.eq(release_project_id))
+            .first::<Release>(&connection)
+            .expect("could not find release");
+
+        // did we make this commit earlier? If so, update it. If not, create it
+        match commits.filter(sha.eq(&sha_name)).first::<Commit>(&connection) {
+            Ok(the_commit) => {
+                diesel::update(commits.find(the_commit.id))
+                    .set(release_id.eq(the_release.id))
+                    .get_result::<Commit>(&connection)
+                    .expect(&format!("Unable to update commit {}", the_commit.id));
+            },
+            Err(_) => {
+                let git_log = Command::new("git")
+                    .arg("-C")
+                    .arg(&path)
+                    .arg("--no-pager")
+                    .arg("show")
+                    .arg(r#"--format=%H %ae %an"#)
+                    .arg(&sha_name)
+                    .output()
+                    .expect("failed to execute process");
+
+                let git_log = git_log.stdout;
+                let git_log = String::from_utf8(git_log).unwrap();
+
+                let log_line = git_log.split('\n').nth(0).unwrap();
+
+                let mut split = log_line.splitn(3, ' ');
+
+                let the_sha = split.next().unwrap();
+                let the_author_email = split.next().unwrap();
+                let the_author_name = split.next().unwrap();
+
+                info!(log, "Creating commit {} for release {}", the_sha, the_release.version);
+
+                ::create_commit(&connection, &the_sha, &the_author_name, &the_author_email, &the_release);
+            },
+        };
+    }
+}
+

--- a/src/releases.rs
+++ b/src/releases.rs
@@ -92,7 +92,7 @@ pub fn assign_commits(log: &Logger, release_name: &str, previous_release: &str, 
 
                 info!(log, "Creating commit {} for release {}", the_sha, the_release.version);
 
-                ::create_commit(&connection, &the_sha, &the_author_name, &the_author_email, &the_release);
+                ::commits::create(&connection, &the_sha, &the_author_name, &the_author_email, &the_release);
             },
         };
     }

--- a/src/releases.rs
+++ b/src/releases.rs
@@ -1,12 +1,24 @@
 use models::{Release, NewRelease};
+use models::Project;
+
+use caseless;
 
 use diesel;
 use diesel::pg::PgConnection;
 use diesel::prelude::*;
 
+use serde_json::value::Value;
+
+use std::cmp::Ordering;
 use std::process::Command;
 
 use slog::Logger;
+
+use unicode_normalization::UnicodeNormalization;
+
+// needed for case-insensitivity
+use diesel::types::VarChar;
+sql_function!(lower, lower_t, (x: VarChar) -> VarChar);
 
 pub fn assign_commits(log: &Logger, release_name: &str, previous_release: &str, release_project_id: i32, path: &str) {
     // Could take the connection as a parameter, as problably
@@ -99,3 +111,90 @@ pub fn create(conn: &PgConnection, version: &str, project_id: i32) -> Release {
         .expect("Error saving new release")
 }
 
+pub fn contributors(project: &str, release_name: &str) -> Option<Vec<Value>> {
+    use schema::releases::dsl::*;
+    use schema::commits::dsl::*;
+    use models::Release;
+    use models::Commit;
+
+    let connection = ::establish_connection();
+
+    let project = {
+        use schema::projects::dsl::*;
+
+        match projects.filter(lower(name).eq(lower(project)))
+            .first::<Project>(&connection) {
+                Ok(p) => p,
+                Err(_) => {
+                    return None;
+                }
+        }
+    };
+
+    let release: Release = match releases
+        .filter(version.eq(release_name))
+        .filter(project_id.eq(project.id))
+        .first(&connection) {
+            Ok(release) => release,
+                Err(_) => {
+                    return None;
+                },
+        };
+
+    // it'd be better to do this in the db
+    // but Postgres doesn't do Unicode collation correctly on OSX
+    // http://postgresql.nabble.com/Collate-order-on-Mac-OS-X-text-with-diacritics-in-UTF-8-td1912473.html
+    let mut names: Vec<String> = Commit::belonging_to(&release)
+        .select(author_name).distinct().load(&connection).unwrap();
+
+    inaccurate_sort(&mut names);
+
+    Some(names.into_iter().map(Value::String).collect())
+}
+
+// TODO: switch this out for an implementation of the Unicode Collation Algorithm
+pub fn inaccurate_sort(strings: &mut Vec<String>) {
+    strings.sort_by(|a, b| str_cmp(&a, &b));
+}
+
+fn str_cmp(a_raw: &str, b_raw: &str) -> Ordering {
+    let a: Vec<char> = a_raw.nfkd().filter(|&c| (c as u32) < 0x300 || (c as u32) > 0x36f).collect();
+    let b: Vec<char> = b_raw.nfkd().filter(|&c| (c as u32) < 0x300 || (c as u32) > 0x36f).collect();
+
+    for (&a_char, &b_char) in a.iter().zip(b.iter()) {
+        match char_cmp(a_char, b_char) {
+            Ordering::Less => return Ordering::Less,
+            Ordering::Greater => return Ordering::Greater,
+            Ordering::Equal => {}
+        }
+    }
+
+    if a.len() < b.len() {
+        Ordering::Less
+    } else if a.len() > b.len() {
+        Ordering::Greater
+    } else {
+        Ordering::Equal
+    }
+}
+
+fn char_cmp(a_char: char, b_char: char) -> Ordering {
+    let a = caseless::default_case_fold_str(&a_char.to_string());
+    let b = caseless::default_case_fold_str(&b_char.to_string());
+
+    let first_char = a.chars().nth(0).unwrap_or('{');
+
+    let order = if a == b && a.len() == 1 && 'a' <= first_char && first_char <= 'z' {
+        if a_char > b_char {
+            Ordering::Less
+        } else if a_char < b_char {
+            Ordering::Greater
+        } else {
+            Ordering::Equal
+        }
+    } else {
+        a.cmp(&b)
+    };
+
+    order
+}

--- a/src/releases.rs
+++ b/src/releases.rs
@@ -198,3 +198,27 @@ fn char_cmp(a_char: char, b_char: char) -> Ordering {
 
     order
 }
+
+pub fn all() -> Vec<Value> {
+    use schema::releases::dsl::*;
+    use models::Release;
+    use models::Project;
+
+    let connection = ::establish_connection();
+
+    let project = {
+        use schema::projects::dsl::*;
+        projects.filter(name.eq("Rust"))
+            .first::<Project>(&connection)
+        .expect("Error finding the Rust project")
+    };
+
+    let results = releases.filter(project_id.eq(project.id))
+        .load::<Release>(&connection)
+        .expect("Error loading releases");
+
+    results.into_iter()
+        .rev()
+        .map(|r| Value::String(r.version))
+        .collect()
+}

--- a/src/releases.rs
+++ b/src/releases.rs
@@ -1,4 +1,7 @@
+use models::{Release, NewRelease};
+
 use diesel;
+use diesel::pg::PgConnection;
 use diesel::prelude::*;
 
 use std::process::Command;
@@ -81,5 +84,18 @@ pub fn assign_commits(log: &Logger, release_name: &str, previous_release: &str, 
             },
         };
     }
+}
+
+pub fn create(conn: &PgConnection, version: &str, project_id: i32) -> Release {
+    use schema::releases;
+
+    let new_release = NewRelease {
+        version: version,
+        project_id: project_id,
+    };
+
+    diesel::insert(&new_release).into(releases::table)
+        .get_result(conn)
+        .expect("Error saving new release")
 }
 


### PR DESCRIPTION
Instead of throwing everything into `lib.rs`, let's start to actually organize some of this so it makes sense.