### PR TITLE
Rename to thanks.

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,1 +1,1 @@
-DATABASE_URL=postgres://postgres:postgres@localhost/rust_thanks
+DATABASE_URL=postgres://postgres:postgres@localhost/thanks

--- a/.env.sample
+++ b/.env.sample
@@ -1,1 +1,1 @@
-DATABASE_URL=postgres://postgres:postgres@localhost/rust_contributors
+DATABASE_URL=postgres://postgres:postgres@localhost/rust_thanks

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,5 +1,5 @@
 [root]
-name = "http"
+name = "thanks"
 version = "0.1.0"
 dependencies = [
  "caseless 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -9,12 +9,15 @@ dependencies = [
  "dotenv 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "handlebars 0.24.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http 0.1.0",
  "hyper 0.11.0-a.0 (git+https://github.com/hyperium/hyper)",
  "regex 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.8.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 0.8.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 0.8.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slog 1.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slog-term 1.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-normalization 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -94,29 +97,6 @@ dependencies = [
  "unicode-segmentation 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "vec_map 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "contributors"
-version = "0.1.0"
-dependencies = [
- "caseless 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "clap 2.19.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "diesel 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "diesel_codegen 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "dotenv 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "handlebars 0.24.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "http 0.1.0",
- "hyper 0.11.0-a.0 (git+https://github.com/hyperium/hyper)",
- "regex 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "reqwest 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.8.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 0.8.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 0.8.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "slog 1.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "slog-term 1.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-normalization 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -254,6 +234,26 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "http"
+version = "0.1.0"
+dependencies = [
+ "caseless 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 2.19.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "diesel 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "diesel_codegen 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dotenv 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "handlebars 0.24.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.11.0-a.0 (git+https://github.com/hyperium/hyper)",
+ "regex 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "reqwest 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.8.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 0.8.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 0.8.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-normalization 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 authors = ["Steve Klabnik <steve@steveklabnik.com>"]
-name = "contributors"
+name = "thanks"
 version = "0.1.0"
 
 [workspace]
 
 [[bin]]
-name = "contributors"
+name = "thanks"
 doc = false
 [[bin]]
 name = "populate"

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: ./target/release/contributors $PORT
+web: ./target/release/thanks $PORT

--- a/README.md
+++ b/README.md
@@ -73,15 +73,15 @@ Open your browser to the URL shown.
 To access the database from the commannd line:
 
 ```bash
-psql -p 5432 -h localhost -U postgres -d rust_thanks
+psql -p 5432 -h localhost -U postgres -d thanks
 ```
 
 If you have the database with the old name (`rust_contributors` or any
 other), you have two options:
 - use the old name in the above command, or:
-- run `psql -p 5432 -h localhost -U postgres`, rename the database by
-  running `ALTER DATABASE rust_contributors RENAME TO rust_thans` and edit
-  `.env` file to use the new name.
+- run `psql -p 5432 -h localhost -U postgres`, rename the database by running
+  `ALTER DATABASE rust_contributors RENAME TO thanks` and edit `.env` file to
+  use the new name.
 
 If you're working on the `populate` binary, it's useful to be able to quickly
 drop your local database:

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ commits that will need to be processed.
 Run the server:
 
 ```bash
-$ cargo run --bin contributors
+$ cargo run --bin thanks
 ```
 
 Open your browser to the URL shown.
@@ -73,8 +73,15 @@ Open your browser to the URL shown.
 To access the database from the commannd line:
 
 ```bash
-psql -p 5432 -h localhost -U postgres -d rust_contributors
+psql -p 5432 -h localhost -U postgres -d rust_thanks
 ```
+
+If you have the database with the old name (`rust_contributors` or any
+other), you have two options:
+- use the old name in the above command, or:
+- run `psql -p 5432 -h localhost -U postgres`, rename the database by
+  running `ALTER DATABASE rust_contributors RENAME TO rust_thans` and edit
+  `.env` file to use the new name.
 
 If you're working on the `populate` binary, it's useful to be able to quickly
 drop your local database:

--- a/http/src/lib.rs
+++ b/http/src/lib.rs
@@ -146,8 +146,8 @@ impl Service for Contributors {
 pub struct Server;
 
 impl Server {
-    pub fn run(&self, addr: &SocketAddr, contributors: Contributors) {
-        let a = std::sync::Arc::new(contributors);
+    pub fn run(&self, addr: &SocketAddr, thanks: Contributors) {
+        let a = std::sync::Arc::new(thanks);
 
         let server = Http::new().bind(addr, move || Ok(a.clone())).unwrap();
 

--- a/migrations/20170131230339_rename_contributors_to_authors/down.sql
+++ b/migrations/20170131230339_rename_contributors_to_authors/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE authors RENAME TO contributors;

--- a/migrations/20170131230339_rename_contributors_to_authors/up.sql
+++ b/migrations/20170131230339_rename_contributors_to_authors/up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE contributors RENAME TO authors;

--- a/src/bin/new-release.rs
+++ b/src/bin/new-release.rs
@@ -1,4 +1,4 @@
-extern crate contributors;
+extern crate thanks;
 
 extern crate diesel;
 extern crate clap;
@@ -46,12 +46,12 @@ fn main() {
     let path = matches.value_of("filepath").unwrap();
     info!(&log, "Path to {} repo: {}", project_name, path);
 
-    use contributors::schema::releases::dsl::*;
-    use contributors::models::Release;
-    use contributors::schema::projects::dsl::{projects, name};
-    use contributors::models::Project;
+    use thanks::schema::releases::dsl::*;
+    use thanks::models::Release;
+    use thanks::schema::projects::dsl::{projects, name};
+    use thanks::models::Project;
 
-    let connection = contributors::establish_connection();
+    let connection = thanks::establish_connection();
 
     let project = projects.filter(name.eq(project_name)).first::<Project>(&connection).expect("Unknown project!");
     let release = Release::belonging_to(&project).order(id.desc()).first::<Release>(&connection).unwrap();
@@ -63,9 +63,9 @@ fn main() {
        panic!("Release {} already exists! Something must be wrong.", new_release_name);
     }
 
-    let new_release = contributors::releases::create(&connection, &new_release_name, project.id);
+    let new_release = thanks::releases::create(&connection, &new_release_name, project.id);
     info!(log, "Created release {}", new_release.version);
 
     info!(log, "Assigning commits for {}", new_release.version);
-    contributors::releases::assign_commits(&log, &new_release.version, &release.version, project.id, &path);
+    thanks::releases::assign_commits(&log, &new_release.version, &release.version, project.id, &path);
 }

--- a/src/bin/the-big-red-button.rs
+++ b/src/bin/the-big-red-button.rs
@@ -1,4 +1,4 @@
-extern crate contributors;
+extern crate thanks;
 
 extern crate clap;
 
@@ -34,7 +34,7 @@ fn main() {
 
     let log = slog::Logger::root(slog_term::streamer().full().build().fuse(), o!("version" => env!("CARGO_PKG_VERSION")));
 
-    let connection = contributors::establish_connection();
+    let connection = thanks::establish_connection();
 
     match matches.is_present("all") {
         true => delete_whole_db(&log, &connection),
@@ -48,11 +48,11 @@ fn main() {
 }
 
 fn delete_projects_db(log: &slog::Logger, connection: &PgConnection, project_name: &str) {
-    use contributors::schema::releases::dsl::*;
-    use contributors::models::Release;
-    use contributors::schema::projects::dsl::{projects, name};
-    use contributors::models::Project;
-    use contributors::schema::commits::dsl::{commits, release_id};
+    use thanks::schema::releases::dsl::*;
+    use thanks::models::Release;
+    use thanks::schema::projects::dsl::{projects, name};
+    use thanks::models::Project;
+    use thanks::schema::commits::dsl::{commits, release_id};
     use diesel::expression::dsl::any;
 
     let project = projects.filter(name.eq(project_name)).first::<Project>(connection).expect("Unknown project!");
@@ -80,9 +80,9 @@ fn delete_projects_db(log: &slog::Logger, connection: &PgConnection, project_nam
 }
 
 fn delete_whole_db(log: &slog::Logger, connection: &PgConnection) {
-    use contributors::schema::releases::dsl::*;
-    use contributors::schema::commits::dsl::*;
-    use contributors::schema::projects::dsl::*;
+    use thanks::schema::releases::dsl::*;
+    use thanks::schema::commits::dsl::*;
+    use thanks::schema::projects::dsl::*;
 
     info!(log, "Deleting commits");
     diesel::delete(commits)

--- a/src/bin/update-commit-db.rs
+++ b/src/bin/update-commit-db.rs
@@ -1,4 +1,4 @@
-extern crate contributors;
+extern crate thanks;
 
 extern crate diesel;
 
@@ -24,7 +24,7 @@ extern crate slog_term;
 
 use slog::DrainExt;
 
-use contributors::models::Project;
+use thanks::models::Project;
 
 #[derive(Debug,Deserialize)]
 struct GitHubResponse(Vec<Object>);
@@ -47,10 +47,10 @@ struct Author {
 }
 
 fn update_commit_db(log: &slog::Logger, project: &Project, connection: &PgConnection) {
-    use contributors::schema::releases::dsl::*;
-    use contributors::models::Release;
-    use contributors::schema::commits::dsl::*;
-    use contributors::models::Commit;
+    use thanks::schema::releases::dsl::*;
+    use thanks::models::Release;
+    use thanks::schema::commits::dsl::*;
+    use thanks::models::Commit;
     use diesel::expression::dsl::any;
 
     let api_link = Url::parse(format!("https://api.github.com/repos/{}/commits", project.github_name).as_str()).unwrap();
@@ -82,7 +82,7 @@ fn update_commit_db(log: &slog::Logger, project: &Project, connection: &PgConnec
             Err(_) => {
                 info!(log, "Creating commit {} for release {}", object.sha, master_release.version);
                 // this commit will be part of master
-                contributors::commits::create(connection, &object.sha, &object.commit.author.name, &object.commit.author.email, &master_release);
+                thanks::commits::create(connection, &object.sha, &object.commit.author.name, &object.commit.author.email, &master_release);
             },
         };
     }
@@ -91,9 +91,9 @@ fn update_commit_db(log: &slog::Logger, project: &Project, connection: &PgConnec
 fn main() {
     let log = slog::Logger::root(slog_term::streamer().full().build().fuse(), o!("version" => env!("CARGO_PKG_VERSION")));
 
-    use contributors::schema::projects::dsl::*;
+    use thanks::schema::projects::dsl::*;
 
-    let connection = contributors::establish_connection();
+    let connection = thanks::establish_connection();
     let projects_to_update: Vec<Project> = projects.load(&connection).expect("No projects found");
     for project in projects_to_update {
         info!(log, "Updating {}", project.name);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-extern crate contributors;
+extern crate thanks;
 
 extern crate dotenv;
 
@@ -47,19 +47,19 @@ fn main() {
         .unwrap();
 
     let server = http::Server;
-    let mut contributors = http::Contributors::new();
+    let mut thanks = http::Contributors::new();
 
-    contributors.add_route("/", root);
+    thanks.add_route("/", root);
 
-    contributors.add_route("/about", about);
+    thanks.add_route("/about", about);
 
-    contributors.add_route("/rust/all-time", all_time);
+    thanks.add_route("/rust/all-time", all_time);
     
-    contributors.add_regex_route("/([^/]+)/(.+)", release);
+    thanks.add_regex_route("/([^/]+)/(.+)", release);
 
     info!(log, "Starting server, listening on http://{}", addr);
 
-    server.run(&addr, contributors);
+    server.run(&addr, thanks);
 }
 
 fn root(_: Request) -> futures::Finished<Response, hyper::Error> {
@@ -67,7 +67,7 @@ fn root(_: Request) -> futures::Finished<Response, hyper::Error> {
 
 
     data.insert("releases".to_string(),
-                Value::Array(contributors::releases::all()));
+                Value::Array(thanks::releases::all()));
 
     let template = build_template(&data, "templates/index.hbs");
 
@@ -89,7 +89,7 @@ fn about(_: Request) -> futures::Finished<Response, hyper::Error> {
 fn all_time(_: Request) -> futures::Finished<Response, hyper::Error> {
     let mut data: BTreeMap = BTreeMap::new();
 
-    let scores = contributors::scores();
+    let scores = thanks::scores();
 
     data.insert("release".to_string(),
                 Value::String(String::from("all-time")));
@@ -114,7 +114,7 @@ fn release(_: &Request, cap: Captures) -> futures::Finished<Response, hyper::Err
 
     data.insert("release".to_string(), Value::String(release_name.to_string()));
 
-    let names = contributors::releases::contributors(project, release_name);
+    let names = thanks::releases::thanks(project, release_name);
 
     match names {
         Some(names) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,7 +54,7 @@ fn main() {
     thanks.add_route("/about", about);
 
     thanks.add_route("/rust/all-time", all_time);
-    
+
     thanks.add_regex_route("/([^/]+)/(.+)", release);
 
     info!(log, "Starting server, listening on http://{}", addr);
@@ -114,7 +114,7 @@ fn release(_: &Request, cap: Captures) -> futures::Finished<Response, hyper::Err
 
     data.insert("release".to_string(), Value::String(release_name.to_string()));
 
-    let names = thanks::releases::thanks(project, release_name);
+    let names = thanks::releases::contributors(project, release_name);
 
     match names {
         Some(names) => {

--- a/src/releases.rs
+++ b/src/releases.rs
@@ -111,7 +111,7 @@ pub fn create(conn: &PgConnection, version: &str, project_id: i32) -> Release {
         .expect("Error saving new release")
 }
 
-pub fn contributors(project: &str, release_name: &str) -> Option<Vec<Value>> {
+pub fn thanks(project: &str, release_name: &str) -> Option<Vec<Value>> {
     use schema::releases::dsl::*;
     use schema::commits::dsl::*;
     use models::Release;

--- a/src/releases.rs
+++ b/src/releases.rs
@@ -111,7 +111,7 @@ pub fn create(conn: &PgConnection, version: &str, project_id: i32) -> Release {
         .expect("Error saving new release")
 }
 
-pub fn thanks(project: &str, release_name: &str) -> Option<Vec<Value>> {
+pub fn contributors(project: &str, release_name: &str) -> Option<Vec<Value>> {
     use schema::releases::dsl::*;
     use schema::commits::dsl::*;
     use models::Release;


### PR DESCRIPTION
Fixes #36.

Added a comment on renaming the database (which is not mandatory of course) in the README.md for everyone who has the db already running and do not want to drop it and the re-populate (this couldn't be automated using migration).