### PR TITLE
"discrete" → "discreet"

### DIFF
--- a/templates/about.hbs
+++ b/templates/about.hbs
@@ -15,6 +15,6 @@
       href="https://github.com/rust-lang-nursery/thanks/issues">open an issue</a> if
       it's okay to publicly discuss, or <a
       href="mailto:steve@steveklabnik.com">email Steve</a> if you'd prefer to be more
-      discrete. We are happy to remove or make edits where appropriate.</p>
+      discreet. We are happy to remove or make edits where appropriate.</p>
 {{/inline}}
 {{~> (parent)~}}


### PR DESCRIPTION
The intended meaning here is surely ["Respectful of privacy or secrecy;
quiet; diplomatic"](https://en.wiktionary.org/wiki/discreet) rather than ["Separate; distinct; individual;
non-continuous"](https://en.wiktionary.org/wiki/discrete). It's alarmingly easy to accidentally type
a homophone rather than the word you intended!