### PR TITLE
Remove a bunch of `::table()`s

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,13 +47,10 @@ pub fn scores() -> Vec<Value> {
     use schema::authors::dsl::*;
     use diesel::expression::dsl::sql;
     use diesel::types::BigInt;
-    use diesel::associations::HasTable;
 
     let connection = establish_connection();
 
-    let scores: Vec<_> =
-        commits::table()
-        .inner_join(authors::table())
+    let scores: Vec<_> = commits.inner_join(authors)
         .filter(visible.eq(true))
         .select((name, sql::<BigInt>("COUNT(author_id) AS author_count")))
         .group_by((author_id, name))

--- a/src/releases.rs
+++ b/src/releases.rs
@@ -117,7 +117,6 @@ pub fn contributors(project: &str, release_name: &str) -> Option<Vec<Value>> {
     use schema::releases::dsl::*;
     use schema::commits::dsl::*;
     use models::Release;
-    use diesel::associations::HasTable;
 
     let connection = ::establish_connection();
 
@@ -147,7 +146,7 @@ pub fn contributors(project: &str, release_name: &str) -> Option<Vec<Value>> {
     // but Postgres doesn't do Unicode collation correctly on OSX
     // http://postgresql.nabble.com/Collate-order-on-Mac-OS-X-text-with-diacritics-in-UTF-8-td1912473.html
     use schema::authors;
-    let mut names: Vec<String> = authors::table.inner_join(commits::table()).filter(release_id.eq(release.id))
+    let mut names: Vec<String> = authors::table.inner_join(commits).filter(release_id.eq(release.id))
         .filter(authors::visible.eq(true)).select(authors::name).distinct().load(&connection).unwrap();
 
     inaccurate_sort(&mut names);


### PR DESCRIPTION
The `table()` function is useless for application code and does nothing.