### PR TITLE
Change `authors::load_or_create` to be less racy

### DIFF
--- a/migrations/20170311163127_authors_name_and_email_should_be_unique/down.sql
+++ b/migrations/20170311163127_authors_name_and_email_should_be_unique/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX authors_name_email_idx;

--- a/migrations/20170311163127_authors_name_and_email_should_be_unique/up.sql
+++ b/migrations/20170311163127_authors_name_and_email_should_be_unique/up.sql
@@ -1,0 +1,1 @@
+CREATE UNIQUE INDEX ON authors (name, email);

--- a/src/authors.rs
+++ b/src/authors.rs
@@ -1,29 +1,32 @@
 use models::{Author, NewAuthor};
 
-use diesel;
-use diesel::result::Error;
+use diesel::*;
 use diesel::pg::PgConnection;
-use diesel::prelude::*;
 
 pub fn load_or_create(conn: &PgConnection, author_name: &str, author_email: &str) -> Author {
-    use schema::authors::dsl::*;
-    use diesel::associations::HasTable;
+    let new_author = NewAuthor {
+        name: author_name,
+        email: author_email,
+    };
 
-    match authors
-        .filter(name.eq(author_name))
-        .filter(email.eq(author_email))
-        .first(conn) {
-            Ok(author) => author,
-            Err(Error::NotFound) => {
-                let new_author = NewAuthor {
-                    name: author_name,
-                    email: author_email,
-                };
-                diesel::insert(&new_author)
-                    .into(authors::table())
-                    .get_result(conn)
-                    .expect("Error saving new author")
-            },
-            Err(_) => panic!("Error loading author from the datebase")
-        }
+    find_or_create(conn, new_author)
+        .expect("Could not find or create author")
+}
+
+fn find_or_create(conn: &PgConnection, new_author: NewAuthor) -> QueryResult<Author> {
+    use schema::authors::dsl::*;
+    use diesel::pg::upsert::*;
+
+    let maybe_inserted = insert(&new_author.on_conflict_do_nothing())
+        .into(authors)
+        .get_result(conn)
+        .optional()?;
+
+    if let Some(author) = maybe_inserted {
+        return Ok(author);
+    }
+
+    authors.filter(name.eq(new_author.name))
+        .filter(email.eq(new_author.email))
+        .first(conn)
 }


### PR DESCRIPTION
This adds a unique constraint on authors (which appears to have been
implicit before, but not verified), and uses upsert to be a bit less
racy. I would have put this as an instance method on `NewAuthor`, but
the code seems to be structured to avoid that as a matter of taste so I
didn't do that restructuring.