### PR TITLE
Populate releases as visible true.  Close #86.

### DIFF
--- a/src/bin/new-release.rs
+++ b/src/bin/new-release.rs
@@ -63,7 +63,7 @@ fn main() {
        panic!("Release {} already exists! Something must be wrong.", new_release_name);
     }
 
-    let new_release = thanks::releases::create(&connection, &new_release_name, project.id);
+    let new_release = thanks::releases::create(&connection, &new_release_name, project.id, true);
     info!(log, "Created release {}", new_release.version);
 
     info!(log, "Assigning commits for {}", new_release.version);

--- a/src/bin/populate.rs
+++ b/src/bin/populate.rs
@@ -140,14 +140,14 @@ fn main() {
 
     // create 0.1, which isn't in the loop because it will have everything assigned
     // to it by default
-    thanks::releases::create(&connection, "0.1", project.id);
+    thanks::releases::create(&connection, "0.1", project.id, true);
 
     for &(release, _) in releases.iter() {
-        thanks::releases::create(&connection, release, project.id);
+        thanks::releases::create(&connection, release, project.id, true);
     }
 
     // And create the release for all commits that are not released yet
-    thanks::releases::create(&connection, "master", project.id);
+    thanks::releases::create(&connection, "master", project.id, true);
 
     // create most commits
     //

--- a/src/models.rs
+++ b/src/models.rs
@@ -63,6 +63,7 @@ use super::schema::releases;
 pub struct NewRelease<'a> {
     pub version: &'a str,
     pub project_id: i32,
+    pub visible: bool,
 }
 
 use super::schema::authors;

--- a/src/releases.rs
+++ b/src/releases.rs
@@ -155,12 +155,13 @@ fn authors_by_sha<'a>(conn: &PgConnection, git_log: Vec<(Sha<'a>, Email, Name)>)
         .collect())
 }
 
-pub fn create(conn: &PgConnection, version: &str, project_id: i32) -> Release {
+pub fn create(conn: &PgConnection, version: &str, project_id: i32, visible: bool) -> Release {
     use schema::releases;
 
     let new_release = NewRelease {
         version: version,
         project_id: project_id,
+        visible: visible,
     };
 
     insert(&new_release).into(releases::table)


### PR DESCRIPTION
This commit fixes populate so that releases are inserted into the database with visible set to true.