### PR TITLE
Insert initial maintenance row.  Closes #94.

### DIFF
--- a/migrations/20170322172200_maintenance_initial_row/down.sql
+++ b/migrations/20170322172200_maintenance_initial_row/down.sql
@@ -1,0 +1,2 @@
+DELETE FROM maintenances
+    WHERE id = 1;

--- a/migrations/20170322172200_maintenance_initial_row/up.sql
+++ b/migrations/20170322172200_maintenance_initial_row/up.sql
@@ -1,0 +1,2 @@
+INSERT INTO maintenances (id, enabled)
+    VALUES (1, false);


### PR DESCRIPTION
This commit changes the maintenance migration to include an insert of an initial row having id = 1 and enabled = false.