### PR TITLE
Greatly improve performance of 'populate'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,3 +16,10 @@ deploy:
     repo: rust-lang-nursery/thanks
   api_key:
     secure: VBtWlKXyNCaU09rAChCIRHaiI44IDNyjNdnPz5PrXDKbstl5Lwrd2CChhrytZuwu97NjY044Fir5AyR4jxl93T1MkedgPQqiFFqgsXS4YacnzbA0p+4E7XVxNiZPqzC93egiPnSXv7Vl0rluzC3Uaa7Gd3vy3Uqzppo0Gje9X2b2VPuwC9+G5IslIUzOxQ5l9HPs3FAJFzcPvDAsXeJMb73P80Bza5IOBPPw1NrZVMUzXAhNwoRb844obPB6+3axXVLg6gTi2DoOcRrWZRfjNCmzmSibIjJNKD31iHy5hO/k04Fn0ZB+fqBu2Toy+MQct7WAmcjEC0Ngr63ticK0TTKwGoG4W74aIJ3EtCOfpxQHWqi1mG2B5WMxS5Du9fowYyHIeTebQ/8QGCIZXZxwRDC6nTm6Ja72QeIgJrh/x0hpiV+ObKeaVtr6hCCIaBXo89M/ncOgvxijXRfmuojewWj9olKlD77FcR5ZNfNFT1WKIWiLnRxeL5P+9xeB6MJfPjKYQsBg/stNSueINY4qEnDWwMy6FSNN7NArBAvjMhp7iBFM278xSQ4P+EsaVqYC8dE/OIMyw4N7/V9SF3gGhA8aH94Lzs0J6kbdnqXHHCkqg7MyReK7d8P2nG3ISCYNDCLHjKeo+mrgIIaPhqXeGPPyEjttYETCdXHEX8d7or8=
+
+addons:
+    apt:
+      packages:
+        - cmake
+      sources:
+        - kalakris-cmake

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,8 +8,10 @@ dependencies = [
  "diesel_codegen 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "dotenv 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "git2 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "handlebars 0.25.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.11.0-a.0 (git+https://github.com/hyperium/hyper)",
+ "lazy_static 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -138,6 +140,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmake"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "gcc 0.3.45 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -166,6 +176,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "curl-sys"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "gcc 0.3.45 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libz-sys 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys 0.9.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -252,6 +275,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "git2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libgit2-sys 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-probe 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys 0.9.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -389,6 +425,43 @@ version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "libgit2-sys"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cmake 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "curl-sys 0.3.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gcc 0.3.45 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libssh2-sys 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libz-sys 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys 0.9.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "libssh2-sys"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cmake 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libz-sys 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys 0.9.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "gcc 0.3.45 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "log"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -524,6 +597,11 @@ dependencies = [
  "libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl-sys 0.9.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "openssl-sys"
@@ -1078,10 +1156,12 @@ dependencies = [
 "checksum cfg-if 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "de1e760d7b6535af4241fca8bd8adf68e2e7edacc6b29f5d399050c5e48cf88c"
 "checksum chrono 0.2.25 (registry+https://github.com/rust-lang/crates.io-index)" = "9213f7cd7c27e95c2b57c49f0e69b1ea65b27138da84a170133fd21b07659c00"
 "checksum clap 2.21.1 (registry+https://github.com/rust-lang/crates.io-index)" = "74a80f603221c9cd9aa27a28f52af452850051598537bb6b359c38a7d61e5cda"
+"checksum cmake 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)" = "d18d68987ed4c516dcc3e7913659bfa4076f5182eea4a7e0038bb060953e76ac"
 "checksum core-foundation 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "25bfd746d203017f7d5cbd31ee5d8e17f94b6521c7af77ece6c9e4b2d4b16c67"
 "checksum core-foundation-sys 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "065a5d7ffdcbc8fa145d6f0746f3555025b9097a9e9cda59f7467abae670c78d"
 "checksum crossbeam 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)" = "0c5ea215664ca264da8a9d9c3be80d2eaf30923c259d03e870388eb927508f97"
 "checksum crypt32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e34988f7e069e0b2f3bfc064295161e489b2d4e04a2e4248fb94360cdf00b4ec"
+"checksum curl-sys 0.3.10 (registry+https://github.com/rust-lang/crates.io-index)" = "c0d909dc402ae80b6f7b0118c039203436061b9d9a3ca5d2c2546d93e0a61aaa"
 "checksum diesel 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "18af4b9d51ba507c688c3e75a14c38d21410f2c41e9423ae829db7c77ccee136"
 "checksum diesel_codegen 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e186258111a273698f926afae6f943a5b7bd2830bab3b60ecf14b02bd0a77714"
 "checksum diesel_infer_schema 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "906d61691e013e00efdbff5269804b01e8f6547442ff5b841b8e37af94627374"
@@ -1093,6 +1173,7 @@ dependencies = [
 "checksum futures-cpupool 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "257b356f43df6266091b58eadffbe881f053a8646c4a8ba9edce98d63814caab"
 "checksum gcc 0.3.45 (registry+https://github.com/rust-lang/crates.io-index)" = "40899336fb50db0c78710f53e87afc54d8c7266fb76262fecc78ca1a7f09deae"
 "checksum gdi32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0912515a8ff24ba900422ecda800b52f4016a56251922d397c576bf92c690518"
+"checksum git2 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "046ae03385257040b2a35e56d9669d950dd911ba2bf48202fbef73ee6aab27b2"
 "checksum handlebars 0.25.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b2249f6f0dc5a3bb2b3b1a8f797dfccbc4b053344d773d654ad565e51427d335"
 "checksum httparse 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a6e7a63e511f9edffbab707141fbb8707d1a3098615fb2adbd5769cdfcc9b17d"
 "checksum hyper 0.10.5 (registry+https://github.com/rust-lang/crates.io-index)" = "43a15e3273b2133aaac0150478ab443fb89f15c3de41d8d93d8f3bb14bf560f6"
@@ -1107,6 +1188,9 @@ dependencies = [
 "checksum lazy_static 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "7291b1dd97d331f752620b02dfdbc231df7fc01bf282a00769e1cdb963c460dc"
 "checksum lazycell 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ce12306c4739d86ee97c23139f3a34ddf0387bbf181bc7929d287025a8c3ef6b"
 "checksum libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)" = "88ee81885f9f04bff991e306fea7c1c60a5f0f9e409e99f6b40e3311a3363135"
+"checksum libgit2-sys 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)" = "d951fd5eccae07c74e8c2c1075b05ea1e43be7f8952245af8c2840d1480b1d95"
+"checksum libssh2-sys 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "91e135645c2e198a39552c8c7686bb5b83b1b99f64831c040a6c2798a1195934"
+"checksum libz-sys 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)" = "e5ee912a45d686d393d5ac87fac15ba0ba18daae14e8e7543c63ebf7fb7e970c"
 "checksum log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "5141eca02775a762cc6cd564d8d2c50f67c0ea3a372cbf1c51592b3e029e10ad"
 "checksum matches 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "efd7622e3022e1a6eaa602c4cea8912254e5582c9c692e9167714182244801b1"
 "checksum memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d8b629fb514376c675b98c1421e80b151d3817ac42d7c667717d282761418d20"
@@ -1122,6 +1206,7 @@ dependencies = [
 "checksum num-traits 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "e1cbfa3781f3fe73dc05321bed52a06d2d491eaa764c52335cf4399f046ece99"
 "checksum num_cpus 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a18c392466409c50b87369414a2680c93e739aedeb498eb2bff7d7eb569744e2"
 "checksum openssl 0.9.9 (registry+https://github.com/rust-lang/crates.io-index)" = "d59714233ccf23bc962f5eddc5d5c551c5848400e5ab01c64dded1743f3e3784"
+"checksum openssl-probe 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "756d49c8424483a3df3b5d735112b4da22109ced9a8294f1f5cdf80fb3810919"
 "checksum openssl-sys 0.9.9 (registry+https://github.com/rust-lang/crates.io-index)" = "376c5c6084e5ea95eea9c3280801e46d0dcf51251d4f01b747e044fb64d1fb31"
 "checksum pest 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0a6dda33d67c26f0aac90d324ab2eb7239c819fc7b2552fe9faa4fe88441edc8"
 "checksum pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "3a8b4c6b8165cd1a1cd4b9b120978131389f64bdaf456435caa41e630edba903"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,8 @@ serde_json = "0.9.0"
 slog = "1.4.1"
 slog-term = "1.3.5"
 unicode-normalization = "0.1.0"
+git2 = "0.6"
+lazy_static = "0.2"
 
 [dependencies.diesel_codegen]
 features = ["postgres"]

--- a/src/authors.rs
+++ b/src/authors.rs
@@ -1,52 +1,177 @@
 use models::{Author, NewAuthor};
+use mailmap::Mailmap;
 
 use diesel::*;
 use diesel::pg::PgConnection;
+use std::collections::HashMap;
+use std::fs::File;
+use std::io::prelude::*;
+use std::io::BufReader;
+use git2::Repository;
+use std::path::Path;
 
-pub fn load_or_create(conn: &PgConnection, author_name: &str, author_email: &str) -> Author {
-    let new_author = NewAuthor {
-        name: author_name,
-        email: author_email,
-    };
+use releases;
 
-    find_or_create(conn, new_author)
-        .expect("Could not find or create author")
+// Postgresql won't execute the query if this is much higher
+const ITEMS_PER_CHUNK: usize = 30_000;
+
+pub struct AuthorStore<'a> {
+    cache: HashMap<(String, String), Author>,
+    conn: &'a PgConnection,
+    mailmap: Mailmap
 }
 
-pub fn find_or_create_all(conn: &PgConnection, new_authors: Vec<NewAuthor>)
-    -> QueryResult<Vec<Author>>
-{
-    use schema::authors::dsl::*;
-    use diesel::expression::dsl::any;
-    use diesel::pg::upsert::*;
-
-    let (names, emails): (Vec<_>, Vec<_>) = new_authors.iter()
-        .map(|author| (author.name, author.email))
-        .unzip();
-
-    insert(&new_authors.on_conflict_do_nothing())
-        .into(authors)
-        .execute(conn)?;
-
-    authors.filter(name.eq(any(names)))
-        .filter(email.eq(any(emails)))
-        .load(conn)
-}
-
-fn find_or_create(conn: &PgConnection, new_author: NewAuthor) -> QueryResult<Author> {
-    use schema::authors::dsl::*;
-    use diesel::pg::upsert::*;
-
-    let maybe_inserted = insert(&new_author.on_conflict_do_nothing())
-        .into(authors)
-        .get_result(conn)
-        .optional()?;
-
-    if let Some(author) = maybe_inserted {
-        return Ok(author);
+impl<'a> AuthorStore<'a> {
+    pub fn new(conn: &'a PgConnection, mailmap: Mailmap) -> AuthorStore<'a> {
+        AuthorStore {
+            cache: HashMap::new(),
+            conn: conn,
+            mailmap: mailmap
+        }
     }
 
-    authors.filter(name.eq(new_author.name))
-        .filter(email.eq(new_author.email))
-        .first(conn)
+    pub fn from_file(conn: &'a PgConnection, path: &str) -> AuthorStore<'a> {
+
+        let file_path = Path::new(path).join(".mailmap");
+
+        let contents = {
+            if file_path.is_file() {
+                let file = File::open(file_path).unwrap();
+
+                let mut buf_reader = BufReader::new(file);
+                let mut contents = String::new();
+                buf_reader.read_to_string(&mut contents).unwrap();
+                contents
+
+            } else {
+                "".to_string()
+            }
+        };
+
+
+        AuthorStore {
+            cache: HashMap::new(),
+            conn: conn,
+            mailmap: Mailmap::new(contents.as_str())
+        }
+
+    }
+
+    pub fn get(&mut self, author_name: &str, author_email: &str) -> Author {
+
+        let new_author = NewAuthor {
+            name: author_name,
+            email: author_email
+        };
+
+        let entry = (author_name.to_string(), author_email.to_string());
+
+        if !self.cache.contains_key(&entry) {
+            let author = self.find_or_create(&new_author).expect("Could not find or create author").clone();
+            self.cache.insert(entry.clone(), author);
+        }
+        self.cache.get(&entry).unwrap().clone()
+    }
+
+    pub fn find_or_create_all<'b>(&mut self, new_authors: Vec<NewAuthor<'b>>) -> Vec<Author> {
+        use schema::authors::dsl::*;
+        use diesel::expression::dsl::any;
+        use diesel::pg::upsert::*;
+
+        let mut found = Vec::new();
+        let mut missing = Vec::new();
+        let mut missing_names = Vec::new();
+        let mut missing_emails = Vec::new();
+
+        // This is more efficient than querying the DB for each author individually
+        for author in new_authors.into_iter() {
+            let (m_name, m_email) = self.mailmap.map(author.name, author.email);
+
+            match self.cache.get(&(m_name.clone(), m_email.clone())) {
+                Some(a) => found.push(a.clone()),
+                None => {
+                    missing.push(author);
+                    missing_names.push(m_name);
+                    missing_emails.push(m_email);
+                }
+            };
+        };
+
+        if !missing.is_empty() {
+            missing.chunks(ITEMS_PER_CHUNK).enumerate().map(|(i, chunk)| {
+
+                let start = i * ITEMS_PER_CHUNK;
+                let end = start + chunk.len();
+
+                let the_names = &missing_names[start..end];
+                let the_emails = &missing_emails[start..end];
+
+                insert(&chunk.on_conflict_do_nothing()).
+                    into(authors).
+                    execute(self.conn).
+                    unwrap();
+
+                let db_authors: Vec<Author> = authors.filter(name.eq(any(the_names.clone())))
+                    .filter(email.eq(any(the_emails.clone())))
+                    .load(self.conn)
+                    .unwrap();
+
+                for new_author in db_authors.into_iter() {
+                    found.push(new_author.clone());
+
+                    self.cache.insert((new_author.name.clone(), new_author.email.clone()), new_author.clone());
+                }
+            }).last();
+        }
+
+        found
+    }
+
+
+    pub fn warm_cache(&mut self, repo: &Repository) {
+        let commits = releases::get_first_commits(repo, "master");
+
+        let authors: Vec<_> = commits.into_iter().map(|id| {
+            let c = repo.find_commit(id).unwrap();
+            let name: String = c.author().to_owned().name().unwrap().to_owned();
+            let email: String = c.author().to_owned().email().unwrap().to_owned();
+            (name, email)
+        }).collect();
+
+        let new_authors: Vec<_> = authors.iter().map(|&(ref name, ref email)| {
+            NewAuthor {
+                name: name.as_str(),
+                email: email.as_str()
+            }
+        }).collect();
+
+        self.find_or_create_all(new_authors);
+    }
+
+    pub fn map_author<'b>(&self, author: NewAuthor<'b>) -> (String, String) {
+        self.mailmap.map(author.name, author.email)
+    }
+
+    pub fn get_mailmap(&self) -> &Mailmap {
+        &self.mailmap
+    }
+
+    fn find_or_create(&self, new_author: &NewAuthor) -> QueryResult<Author> {
+        use schema::authors::dsl::*;
+        use diesel::pg::upsert::*;
+
+        let maybe_inserted = insert(&new_author.on_conflict_do_nothing())
+            .into(authors)
+            .get_result(self.conn)
+            .optional()?;
+
+        if let Some(author) = maybe_inserted {
+            return Ok(author);
+        }
+
+        authors.filter(name.eq(new_author.name))
+            .filter(email.eq(new_author.email))
+            .first(self.conn)
+    }
 }
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,9 +3,13 @@ extern crate diesel;
 #[macro_use]
 extern crate diesel_codegen;
 
+#[macro_use]
+extern crate lazy_static;
+
 extern crate dotenv;
 
 extern crate semver;
+extern crate regex;
 
 use diesel::prelude::*;
 use diesel::pg::PgConnection;
@@ -14,6 +18,7 @@ use dotenv::dotenv;
 
 extern crate caseless;
 extern crate unicode_normalization;
+extern crate git2;
 
 use std::env;
 
@@ -32,6 +37,7 @@ pub mod projects;
 pub mod releases;
 pub mod commits;
 pub mod authors;
+pub mod mailmap;
 
 use serde_json::value::Value;
 
@@ -100,6 +106,6 @@ pub fn in_maintenance() -> bool {
     let model = maintenances.find(1)
             .load::<Maintenance>(&connection)
             .expect("Error loading maintenance model").remove(0);
-    
+
     model.enabled
 }

--- a/src/mailmap.rs
+++ b/src/mailmap.rs
@@ -1,0 +1,160 @@
+use std::collections::HashMap;
+use regex::Regex;
+
+const WHITESPACE: &'static str = r#"\s*"#;
+const MATCH_NAME: &'static str = "([^<>]+)";
+const MATCH_EMAIL: &'static str = "<([^<>]+)>";
+
+// 'PNAME' =  Proper Name
+// 'PEMAIL =  Proper Email
+// 'CNAME' =  Commit Name
+// 'CEMAIL' = Commit Email
+lazy_static! {
+    static ref PNAME_CEMAIL:             Regex = Regex::new(format!(r#"^{}{} {}\s*(#.*)?$"#,       WHITESPACE, MATCH_NAME,  MATCH_EMAIL).as_str()).unwrap();
+    static ref PEMAIL_CEMAIL:            Regex = Regex::new(format!(r#"^{}{} {}\s*(#.*)?$"#,       WHITESPACE, MATCH_EMAIL, MATCH_EMAIL).as_str()).unwrap();
+    static ref PNAME_PEMAIL_CEMAIL:      Regex = Regex::new(format!(r#"^{}{} {} {}\s*(#.*)?$"#,    WHITESPACE, MATCH_NAME,  MATCH_EMAIL, MATCH_EMAIL).as_str()).unwrap();
+    static ref PNAME_PEMAIL_CNAME_CMAIL: Regex = Regex::new(format!(r#"^{}{} {} {} {}\s*(#.*)?"#, WHITESPACE, MATCH_NAME,  MATCH_EMAIL, MATCH_NAME, MATCH_EMAIL).as_str()).unwrap();
+}
+
+#[derive(Debug)]
+struct Replacement {
+    name: Option<String>,
+    email: Option<String>
+}
+
+impl Replacement {
+    fn name(name: String) -> Replacement {
+        Replacement {
+            name: Some(name),
+            email: None
+        }
+    }
+
+    fn email(email: String) -> Replacement {
+        Replacement {
+            name: None,
+            email: Some(email)
+        }
+    }
+
+    fn both(name: String, email: String) -> Replacement {
+        Replacement {
+            name: Some(name),
+            email: Some(email)
+        }
+    }
+}
+
+pub struct Mailmap {
+    email_map: HashMap<String, Replacement>, // Cache 'not found' to save a lookup
+    name_email_map: HashMap<(String, String), (String, String)>
+}
+
+impl Mailmap {
+    pub fn new(data: &str) -> Mailmap {
+        let mut map = Mailmap {
+            email_map: HashMap::new(),
+            name_email_map: HashMap::new()
+        };
+        map.parse_map(data);
+        map
+    }
+
+    fn parse_map(&mut self, data: &str) {
+        macro_rules! capture {
+            ($cap:expr, $n:expr) => {
+                $cap.get($n).unwrap().as_str().to_owned()
+            }
+        }
+
+        for line in data.split("\n") {
+            if line.starts_with("#") {
+                continue;
+            }
+            if let Some(cap) = PNAME_CEMAIL.captures(line) {
+                //println!("PNAME_CEMAIL: '{}' {:?}", line, cap);
+                self.email_map.insert(capture!(cap, 2).to_lowercase(), Replacement::name(capture!(cap, 1)));
+            } else if let Some(cap) = PEMAIL_CEMAIL.captures(line) {
+                //println!("PEMAIL_CEMAIL: '{}' {:?}", line, cap);
+                self.email_map.insert(capture!(cap, 2).to_lowercase(), Replacement::email(capture!(cap, 1)));
+            } else if let Some(cap) = PNAME_PEMAIL_CEMAIL.captures(line) {
+                //println!("PNAME_PEMAIL_CEMAIL: '{}' {:?}", line, cap);
+                self.email_map.insert(capture!(cap, 3).to_lowercase(), Replacement::both(capture!(cap, 1), capture!(cap, 2)));
+            } else if let Some(cap) = PNAME_PEMAIL_CNAME_CMAIL.captures(line) {
+                //println!("PNAME_PEMAIL_CNAME_CMAIL: '{}' {:?}", line, cap);
+                self.name_email_map.insert((capture!(cap, 3).to_lowercase(), capture!(cap, 4).to_lowercase()), (capture!(cap, 1), capture!(cap, 2)));
+            }
+        }
+    }
+
+    pub fn map(&self, name: &str, email: &str) -> (String, String) {
+        //println!("Lookup: ({}, {}) -> {:?}", name, email, self.email_map.get(email));
+        let (lower_name, lower_email) = (name.to_lowercase(), email.to_lowercase()) ;
+        if let Some(r) = self.email_map.get(&lower_email) {
+            return (r.name.as_ref().map(|s| s.clone()).unwrap_or(name.to_owned()).clone(), r.email.as_ref().map(|s| s.clone()).unwrap_or(email.to_owned()).clone())
+        }
+
+        if let Some(&(ref r_name, ref r_email)) = self.name_email_map.get(&(lower_name.clone(), lower_email.clone())) {
+            return (r_name.clone(), r_email.clone());
+        } else {
+            return (name.to_owned(), email.to_owned());
+        }
+    }
+}
+
+#[test]
+fn test_mailmap() {
+
+    macro_rules! check_map {
+        ($map:expr, $name:expr, $email:expr, $expected_name:expr, $expected_email:expr) => {
+            {
+                let result: (String, String) = $map.map($name, $email);
+                assert_eq!(($expected_name.to_owned(), $expected_email.to_owned()), result, "Expected to map '{},{}' to '{},{}', but instead mapped to '{},{}'", $name, $email, $expected_name, $expected_email, result.0, result.1);
+            }
+        }
+     }
+
+    let map_data = "Other Name <othername@example.com>
+Three Four <threefour@example.com> # This is a comment
+<properemail@example.com> <commitemail@example.com>
+Bob Jones <bobjones@example.com> <fakejones@example.com>
+# Comment line!
+# Another comment
+John Doe <johndoe@example.com> That Guy <thatguy@example.com>
+Am Valid <valid@example.com> Also Valid <alsovalid@example.com> Not Valid <notvalid@example.com>";
+
+    let m = Mailmap::new(map_data);
+
+    // Authors not in the mailmap should be unchanged
+    check_map!(m, "Not Here", "nothere@gmail.com", "Not Here", "nothere@gmail.com");
+
+    // Ensure that non-mailmapped people with multiple names for one email work properly
+    check_map!(m, "Kinda Here", "nothere@gmail.com", "Kinda Here", "nothere@gmail.com");
+
+    // PNAME_CEMAIL rule
+    check_map!(m, "Wrong name", "othername@example.com", "Other Name", "othername@example.com");
+    check_map!(m, "One Two", "threefour@example.com", "Three Four", "threefour@example.com");
+
+    // EMAIL_CEMAIL rule
+    check_map!(m, "Aaron Hill", "commitemail@example.com", "Aaron Hill", "properemail@example.com");
+    check_map!(m, "Random Name", "commitemail@example.com", "Random Name", "properemail@example.com");
+
+    // PNAME_PEMAIL_CEMAIL
+    check_map!(m, "Some Person", "fakejones@example.com", "Bob Jones", "bobjones@example.com");
+    check_map!(m, "Someone Else", "fakejones@example.com", "Bob Jones", "bobjones@example.com");
+
+    // PNAME_PEMAIL_CNAME_CMAIL
+    check_map!(m, "That Guy", "thatguy@example.com", "John Doe", "johndoe@example.com");
+
+    // Requires name and email to both match
+    check_map!(m, "Other Guy", "thatguy@example.com", "Other Guy", "thatguy@example.com");
+    check_map!(m, "That Guy", "blablah@example.com", "That Guy", "blablah@example.com");
+
+    // Any name/email pairs after the second one should be ignored (for compatibility with git)
+    check_map!(m, "Also Valid", "alsovalid@example.com", "Am Valid", "valid@example.com");
+    check_map!(m, "Not Valid", "notvalid@example.com", "Not Valid", "notvalid@example.com");
+
+    // Name/email comparisons are case-insensitive, but original case is preserved when replacement does not occur
+    check_map!(m, "Wrong name", "OtHername@exAmple.com", "Other Name", "OtHername@exAmple.com");
+    check_map!(m, "THAT guy", "ThATguy@examPle.com", "John Doe", "johndoe@example.com");
+}

--- a/src/models.rs
+++ b/src/models.rs
@@ -27,7 +27,7 @@ pub struct Release {
     pub visible: bool,
 }
 
-#[derive(Debug,Identifiable,Queryable,Associations)]
+#[derive(Debug,Identifiable,Queryable,Associations, Clone)]
 #[has_many(commits)]
 pub struct Author {
     pub id: i32,
@@ -68,7 +68,7 @@ pub struct NewRelease<'a> {
 
 use super::schema::authors;
 
-#[derive(Insertable)]
+#[derive(Insertable, Debug, PartialEq, Eq, Hash, Copy, Clone)]
 #[table_name="authors"]
 pub struct NewAuthor<'a> {
     pub name: &'a str,


### PR DESCRIPTION
This PR makes several changes to speed up parsing and storing commits and
authors:

* 'libgit2' is now used to read commits and authors from disk.
Previously, the (formatted) output of 'git log' was parsed, incurring
significant overhead in string parsing
* Authors are now cached in memory, instead of being complete re-fetched
for every release. This allows database queries for finding/creating
authors to be avoided entirely for most releases - some corner cases
such as backported commits prevent all commits from being discovered at
the start

Since libgit2 does not support the 'mailmap' feature of git, this is
implemented within the 'mailmap' module.

On my machine, this commit consistently brings the runtime of `populate` from more than 5 minutes to 13-16 seconds.

I've written up a [short Python script](https://gist.github.com/Aaron1011/d719a84389381631c3cafb14bf848b46) (requires `requests`, runs on Python 2 and 3) to compare the output of each rendered release page. This script expects the webserver from the current `master` to be running at `localhost:2000`, while the webserver from this PR should be running at `localhost:1334`. Except for the following differences, the rendered pages should be identical character-for-character:

* `Dan W.` is now displayed as `Dan W`. This is a consequence of `libgit2` implementing [git's removal of 'crud'](https://stackoverflow.com/questions/26159274/is-it-possible-to-have-a-trailing-period-in-user-name-in-git) when it reads commits from disk. This is slightly different from `git` itself, which only removes 'crud' when the commit is first made - the stripping of trailing characters is not performed by `git log`. This is a fairly minor issue, and could be rectified if necessary by a `mailmap` entry in `rust` removing the 'invalid' period.
* Several authors appear to be removed (e.g. `bluss`). This is a consequence of the current version of `thanks` using [different format specifiers in `populate`](https://github.com/rust-lang-nursery/thanks/blob/7fbe214bc8c7aec6dff89d82f6f50a728d6c6ecb/src/bin/populate.rs#L162) than in [releases](https://github.com/rust-lang-nursery/thanks/blob/7fbe214bc8c7aec6dff89d82f6f50a728d6c6ecb/src/releases.rs#L57). Specifically, the former properly used the mailmap'd name, while the latter does not. My PR ensure that all author names and emails are properly mailmap'd, removing the incorrect authors from the contributors list.
* The contributer Mario (as seen in this commit: https://github.com/rust-lang/rust/commit/ec4a3cc3710eba9b31e00) has their name incorrectly parsed as 'Sopena Mario'. This is due to the fact that the email address for the commit was set to 'Mario Sopena', causing [this code which expected emails to lack whitespace](https://github.com/rust-lang-nursery/thanks/blob/7fbe214bc8c7aec6dff89d82f6f50a728d6c6ecb/src/bin/populate.rs#L185-L188) to fail. Since my PR uses `libgit2`, this is no longer an issue - Mario's name is now displayed correctly in the contributor list.
* The 'All time' page has many commits moved around within their rank. This is because the ordering within a contribution rank is determined by whatever order the database returns the records it, and therefore isn't guaranteed to be consistent. However, all of the committers are still assigned their proper rank.