### PR TITLE
doc: update diesel_cli install flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ up with your local postgres install.
 Build it:
 
 ```bash
-$ cargo install diesel_cli
+$ cargo install diesel_cli --no-default-features --features postgres
 $ diesel setup
 $ cargo build
 ```


### PR DESCRIPTION
Since we're using Postgres, we should be specific about the features we require of diesel_cli. For instance, I do not have MySQL on my dev machine and `cargo install diesel_cli` was failing on the missing dependency