### PR TITLE
Remove unnecessary fonts

### DIFF
--- a/templates/container.hbs
+++ b/templates/container.hbs
@@ -5,16 +5,6 @@
     <title>Rust Contributors</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
-    <!-- fonts -->
-    <link rel="preload" as="font" crossorigin href="/fonts/AlfaSlabOne-Regular.ttf">
-    <link rel="preload" as="font" crossorigin href="/fonts/FiraSans-ExtraBold.ttf">
-    <link rel="preload" as="font" crossorigin href="/fonts/FiraSans-ExtraBoldItalic.ttf">
-    <link rel="preload" as="font" crossorigin href="/fonts/FiraSans-Italic.ttf">
-    <link rel="preload" as="font" crossorigin href="/fonts/FiraSans-Italic.ttf">
-    <link rel="preload" as="font" crossorigin href="/fonts/FiraSans-Regular.ttf">
-    <link rel="preload" as="font" crossorigin href="/fonts/FiraSans-SemiBold.ttf">
-    <link rel="preload" as="font" crossorigin href="/fonts/FiraSans-SemiBoldItalic.ttf">
-
     <!-- styles -->
     <link rel="stylesheet" href="/styles/vendor.css" />
     <link rel="stylesheet" href="/styles/fonts.css" />


### PR DESCRIPTION
It seems that we replaced ttf with woff and ttf is unused at now(return 404). So these should be removed.